### PR TITLE
Generally clean up identifiers.

### DIFF
--- a/buildah/handle.go
+++ b/buildah/handle.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package buildah_ci
+package buildah
 
 import (
 	"strconv"

--- a/buildah/state.go
+++ b/buildah/state.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package buildah_ci
+package buildah
 
 import (
 	"sync"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Vaelatern/nomad-driver-buildah-ci
+module github.com/vaelatern/nomad-driver-buildah
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	buildah_ci "github.com/Vaelatern/nomad-driver-buildah-ci/buildah-ci"
+	"github.com/vaelatern/nomad-driver-buildah/buildah"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/plugins"
@@ -17,5 +17,5 @@ func main() {
 
 // factory returns a new instance of a nomad driver plugin
 func factory(log hclog.Logger) interface{} {
-	return buildah_ci.NewPlugin(log)
+	return buildah.NewPlugin(log)
 }


### PR DESCRIPTION
This patch generally cleans up package and type identifiers.  All internal package names are lower cased, and underscores are removed.

I also removed references to the acryonym "CI" as this could be used for more than just CI, and it made the type less fluid to read.